### PR TITLE
Output home_url() instead of site_url()

### DIFF
--- a/admin/class-permalinks-customizer-posttypes-settings.php
+++ b/admin/class-permalinks-customizer-posttypes-settings.php
@@ -96,7 +96,7 @@ class Permalinks_Customizer_PostTypes_Settings {
           <tr valign="top">
             <th scope="row"><?php echo $post_type->labels->name; ?></th>
             <td>
-              <?php echo site_url(); ?>/<input type="text" name="<?php echo $perm_struct; ?>" value="<?php echo $value; ?>" class="regular-text" />
+              <?php echo home_url(); ?>/<input type="text" name="<?php echo $perm_struct; ?>" value="<?php echo $value; ?>" class="regular-text" />
             </td>
           </tr>
           <?php } ?>

--- a/admin/class-permalinks-customizer-taxonomies-settings.php
+++ b/admin/class-permalinks-customizer-taxonomies-settings.php
@@ -88,7 +88,7 @@ class Permalinks_Customizer_Taxonomies_Settings {
           <tr valign="top">
             <th scope="row"><?php echo $taxonomy->labels->name; ?></th>
             <td>
-              <?php echo site_url(); ?>/<input type="text" name="<?php echo $taxonomy->name; ?>" value="<?php echo $value; ?>" class="regular-text" />
+              <?php echo home_url(); ?>/<input type="text" name="<?php echo $taxonomy->name; ?>" value="<?php echo $value; ?>" class="regular-text" />
             </td>
           </tr>
           <?php } ?>


### PR DESCRIPTION
`site_url()` isn't always guaranteed that will have the right root path of the site, on WordPress projects managed with composer ([WP Starter](https://wecodemore.github.io/wpstarter/)) it can return `http://mywebsite.com/wp/`, best practice would be to use `home_url()`.

![2020-08-17_19-58](https://user-images.githubusercontent.com/3847077/90477214-da1ec580-e0df-11ea-83a5-1366bd893c8d.png)
